### PR TITLE
Silence no-undef in <For> and add default config

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,21 +16,17 @@ If you installed `ESLint` globally, you have to install React plugin globally to
 $ npm install eslint-plugin-jsx-control-statements
 ```
 
-# Configuration
+# Configuration (Simple)
 
-Add `plugins` section and specify ESLint-plugin-JSX-Control-Statements as a plugin.
-Also add `If`, `Else` and `For` to globals.
+Add `plugins` section and specify ESLint-plugin-JSX-Control-Statements as a plugin and plugin:jsx-control-statements/recommended
+to "extends"
 
 ```json
 {
   "plugins": [
     "jsx-control-statements"
   ],
-  "globals": {
-      "If": true,
-      "Else": true,
-      "For": true
-  }
+  "extends": ["plugin:jsx-control-statements/recommended"]
 }
 ```
 
@@ -42,11 +38,11 @@ If it is not already the case you must also configure `ESLint` to support JSX.
     "jsx": true
   }
 }
-```
 
-Finally, enable all of the rules that you would like to use.
+# Configuration (Advanced)
+The plugin comes with a number of rules and an environment that sets the control statements (`<If>`, `<For>` etc) as global variables:
 
-```json
+```js
 {
   "rules": {
     "jsx-control-statements/jsx-choose-not-empty": 1,
@@ -55,7 +51,12 @@ Finally, enable all of the rules that you would like to use.
     "jsx-control-statements/jsx-if-require-condition": 1,
     "jsx-control-statements/jsx-otherwise-once-last": 1,
     "jsx-control-statements/jsx-use-if-tag": 1,
-    "jsx-control-statements/jsx-when-require-condition": 1
+    "jsx-control-statements/jsx-when-require-condition": 1,
+    "jsx-control-statements/jsx-jcs-no-undef": 1,
+    "no-undef": 0 // Replace this with jsx-jcs-no-undef
+  },
+  env: {
+    "jsx-control-statements/jsx-control-statements": true
   }
 }
 ```
@@ -68,12 +69,13 @@ Finally, enable all of the rules that you would like to use.
 * [jsx-otherwise-once-last](docs/rules/jsx-otherwise-once-last.md): Warn when `Otherwise` tag is used more than once inside `Choose` and is not last child.
 * [jsx-use-if-tag](docs/rules/jsx-use-if-tag.md): Use `If` tag instead of ternary operator.
 * [jsx-when-require-condition](docs/rules/jsx-when-require-condition.md): Warn if `When` tag is missing `condition` attribute.
+* [jsx-jcs-no-undef](docs/rules/jsx-when-require-condition.md): Replaces the built-in no-undef rule with one that is tolerant of variables expressed in `<For>`
+     `each` and `index` attributes. Note that to stop getting errors from `no-undef` you have to turn it off and this on.
 
 ## Credits
 Thanks to @yannickcr for his awesome [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react).
 
 ## License
-
 [MIT License](http://www.opensource.org/licenses/mit-license.php). Copyright(c) [Vivek Kumar Bansal](http://vkbansal.me/)
 
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The plugin comes with a number of rules and an environment that sets the control
 * [jsx-otherwise-once-last](docs/rules/jsx-otherwise-once-last.md): Warn when `Otherwise` tag is used more than once inside `Choose` and is not last child.
 * [jsx-use-if-tag](docs/rules/jsx-use-if-tag.md): Use `If` tag instead of ternary operator.
 * [jsx-when-require-condition](docs/rules/jsx-when-require-condition.md): Warn if `When` tag is missing `condition` attribute.
-* [jsx-jcs-no-undef](docs/rules/jsx-when-require-condition.md): Replaces the built-in no-undef rule with one that is tolerant of variables expressed in `<For>`
+* [jsx-jcs-no-undef](docs/rules/jsx-jcs-no-undef.md): Replaces the built-in no-undef rule with one that is tolerant of variables expressed in `<For>`
      `each` and `index` attributes. Note that to stop getting errors from `no-undef` you have to turn it off and this on.
 
 ## Credits

--- a/docs/rules/jsx-jcs-no-undef.md
+++ b/docs/rules/jsx-jcs-no-undef.md
@@ -1,0 +1,44 @@
+# Disallow Undeclared Variables, While Treating Each and Index in For statements as declared (jsx-jcs-no-undef)
+
+This rule is the same as the generic eslint no-undef rule (see http://eslint.org/docs/rules/no-undef) except with an
+exception built in for variables that are implicitly declared by `<For>` statements. Note that this includes no-undef's
+code and completely replaces it rather than supplementing it - if this rule is on, no-undef should be off. It is
+compatible with no-undef's options and `/* global */` declarations.
+
+## Rule Details
+
+The following patterns are considered warnings:
+
+```js
+var a = someFunction();
+b = 10;
+```
+
+```js
+<For of={anArray}>
+  {element}{index}
+</For>
+```
+
+The following patterns are not warnings:
+
+```js
+<For of={anArray} each="element" index="index">
+  {element}{index}
+</For>
+```
+
+## Options
+
+* `typeof` set to true will warn for variables used inside typeof check (Default false).
+
+## When Not To Use It
+
+You'll only need this if you're using <For> statements.
+
+## Compatibility
+
+This rule is completely compatible with ESLint no-undef, except in the case of `<For>` statements.
+
+## Further Reading
+- [ESLint no-undef documentation](http://eslint.org/docs/rules/no-undef)

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ module.exports = {
         "jsx-if-require-condition": require("./lib/rules/jsx-if-require-condition"),
         "jsx-otherwise-once-last": require("./lib/rules/jsx-otherwise-once-last"),
         "jsx-use-if-tag": require("./lib/rules/jsx-use-if-tag"),
-        "jsx-when-require-condition": require("./lib/rules/jsx-when-require-condition")
+        "jsx-when-require-condition": require("./lib/rules/jsx-when-require-condition"),
+        "jcs-no-undef": require("./lib/rules/jcs-no-undef")
     }
 };

--- a/index.js
+++ b/index.js
@@ -1,6 +1,18 @@
 "use strict";
 
 module.exports = {
+    environments: {
+        "jsx-control-statements": {
+            globals: {
+                "If": true,
+                "Else": true,
+                "For": true,
+                "When": true,
+                "Choose": true,
+                "Otherwise": true
+            }
+        }
+    },
     rules: {
         "jsx-choose-not-empty": require("./lib/rules/jsx-choose-not-empty"),
         "jsx-for-require-each": require("./lib/rules/jsx-for-require-each"),
@@ -9,6 +21,24 @@ module.exports = {
         "jsx-otherwise-once-last": require("./lib/rules/jsx-otherwise-once-last"),
         "jsx-use-if-tag": require("./lib/rules/jsx-use-if-tag"),
         "jsx-when-require-condition": require("./lib/rules/jsx-when-require-condition"),
-        "jcs-no-undef": require("./lib/rules/jcs-no-undef")
+        "jsx-jcs-no-undef": require("./lib/rules/jsx-jcs-no-undef")
+    },
+    configs: {
+        recommended: {
+            env: {
+              "jsx-control-statements/jsx-control-statements": true
+            },
+            rules: {
+                "jsx-control-statements/jsx-choose-not-empty": 1,
+                "jsx-control-statements/jsx-for-require-each": 1,
+                "jsx-control-statements/jsx-for-require-of": 1,
+                "jsx-control-statements/jsx-if-require-condition": 1,
+                "jsx-control-statements/jsx-otherwise-once-last": 1,
+                "jsx-control-statements/jsx-use-if-tag": 1,
+                "jsx-control-statements/jsx-when-require-condition": 1,
+                "jsx-control-statements/jsx-jcs-no-undef": 1,
+                "no-undef": 0
+            }
+        }
     }
 };

--- a/lib/rules/jcs-no-undef.js
+++ b/lib/rules/jcs-no-undef.js
@@ -51,7 +51,6 @@ module.exports = function(context) {
                         }, {});
 
                         if (attrMap.each.value.value === identifier.name || attrMap.index.value.value === identifier.name) {
-                            console.log('Woo!');
                             return;
                         }
                     }

--- a/lib/rules/jcs-no-undef.js
+++ b/lib/rules/jcs-no-undef.js
@@ -1,0 +1,80 @@
+/**
+ * Version of https://github.com/eslint/eslint/blob/master/lib/rules/no-undef.js that filters out variables created
+ * by JSX Control Statements for statements.
+ */
+"use strict";
+
+var utils = require("../utils");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Checks if the given node is the argument of a typeof operator.
+ * @param {ASTNode} node The AST node being checked.
+ * @returns {boolean} Whether or not the node is the argument of a typeof operator.
+ */
+function hasTypeOfOperator(node) {
+    var parent = node.parent;
+
+    return parent.type === "UnaryExpression" && parent.operator === "typeof";
+}
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+    var options = context.options[0];
+    var considerTypeOf = options && options.typeof === true || false;
+
+    return {
+        "Program:exit": function(/* node */) {
+            var globalScope = context.getScope();
+
+            globalScope.through.forEach(function(ref) {
+                var identifier = ref.identifier;
+
+                if (!considerTypeOf && hasTypeOfOperator(identifier)) {
+                    return;
+                }
+
+                var thisElement = identifier;
+                while (thisElement.parent) {
+                    thisElement = thisElement.parent;
+
+                    if (thisElement.type === 'JSXElement' && utils.isForComponent(thisElement.openingElement)) {
+                        var attrMap = thisElement.openingElement.attributes.reduce(function(result, attr) {
+                            result[attr.name.name] = attr;
+                            return result;
+                        }, {});
+
+                        if (attrMap.each.value.value === identifier.name || attrMap.index.value.value === identifier.name) {
+                            console.log('Woo!');
+                            return;
+                        }
+                    }
+                }
+
+                context.report({
+                    node: identifier,
+                    message: "'{{name}}' is not defined.",
+                    data: identifier
+                });
+            });
+        }
+    };
+};
+
+module.exports.schema = [
+    {
+        "type": "object",
+        "properties": {
+            "typeof": {
+                "type": "boolean"
+            }
+        },
+        "additionalProperties": false
+    }
+];

--- a/lib/rules/jsx-jcs-no-undef.js
+++ b/lib/rules/jsx-jcs-no-undef.js
@@ -1,4 +1,7 @@
 /**
+ * @fileoverview Extends generic eslint no-undef rule with custom logic for <For> statements.
+ * @author Alex Gilleran
+ *
  * Version of https://github.com/eslint/eslint/blob/master/lib/rules/no-undef.js that filters out variables created
  * by JSX Control Statements for statements.
  */
@@ -40,16 +43,21 @@ module.exports = function(context) {
                     return;
                 }
 
+                // Recurse up the tree of ancestors.
                 var thisElement = identifier;
                 while (thisElement.parent) {
                     thisElement = thisElement.parent;
 
-                    if (thisElement.type === 'JSXElement' && utils.isForComponent(thisElement.openingElement)) {
+                    // If this ancestor is a <For> element...
+                    if (thisElement.type === "JSXElement" && utils.isForComponent(thisElement.openingElement)) {
+                        // Index the <For>'s attributes by name.
                         var attrMap = thisElement.openingElement.attributes.reduce(function(result, attr) {
-                            result[attr.name.name] = attr;
+                            var map = result; // reassign this to appease eslint.
+                            map[attr.name.name] = attr;
                             return result;
                         }, {});
 
+                        // If the undefined variable is specified in "each" or "index", that's fine - ignore it.
                         if (attrMap.each.value.value === identifier.name || attrMap.index.value.value === identifier.name) {
                             return;
                         }

--- a/lib/rules/jsx-use-if-tag.js
+++ b/lib/rules/jsx-use-if-tag.js
@@ -17,7 +17,7 @@ module.exports = function(context) {
     return {
         ConditionalExpression: function(node) {
             if (node.alternate.type === "JSXElement" || node.consequent.type === "JSXElement") {
-                context.report(node, "Ternary opertor used. Use 'If' tag instead.");
+                context.report(node, "Ternary operator used. Use 'If' tag instead.");
             }
         }
     };

--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
     "jsx-control-statements"
   ],
   "license": "MIT",
-  "dependencies": {}
+  "dependencies": {},
+  "peerDependencies": {
+    "eslint": ">=0.8.0"
+  }
 }

--- a/tests/lib/rules/jsx-jcs-no-undef.js
+++ b/tests/lib/rules/jsx-jcs-no-undef.js
@@ -1,0 +1,253 @@
+/**
+ * @fileoverview Tests for JSX Control Statements no-undef.
+ * @author Alex Gilleran
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require("../../../lib/rules/jsx-jcs-no-undef"),
+    RuleTester = require("eslint").RuleTester;
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var ruleTester = new RuleTester();
+
+ruleTester.run("jsx-jcs-no-undef", rule, {
+    valid: [
+        {
+            code: `
+                <For each="element" of={this.props.elements} index="idx">
+                    {element.textValue}
+                    {idx}
+                    <div>
+                        {element.textValue}
+                        {idx}
+                    </div>
+                </For>
+            `,
+            parserOptions: {
+                ecmaFeatures: {
+                    jsx: true
+                }
+            }
+        }, {
+            code: `
+                <For each="element" of={this.props.elements} index="idx">
+                    <AnotherElement foo={element} bar={idx}>
+                        <YetAnotherElement foo={element} bar={idx} />
+                    </AnotherElement>
+                </For>
+            `,
+            parserOptions: {
+                ecmaFeatures: {
+                    jsx: true
+                }
+            }
+        }, {
+            code: `
+                <For each="element1" of={this.props.elements} index="idx1">
+                    <For each="element2" of={this.props.elements} index="idx2">
+                        {element1} {element2} {idx1} {idx2}
+                    </For>
+                </For>
+            `,
+            parserOptions: {
+                ecmaFeatures: {
+                    jsx: true
+                }
+            }
+        },
+
+        // Standard no-undef rules follow:
+        "var a = 1, b = 2; a;",
+        "/*global b*/ function f() { b; }",
+        {code: "function f() { b; }", globals: {b: false}},
+        {code: "function f() { b; }", global: {b: false}},
+        "/*global b a:false*/  a;  function f() { b; a; }",
+        "function a(){}  a();",
+        "function f(b) { b; }",
+        "var a; a = 1; a++;",
+        "var a; function f() { a = 1; }",
+        "/*global b:true*/ b++;",
+        "/*eslint-env browser*/ window;",
+        "/*eslint-env browser*/ window;",
+        "/*eslint-env node*/ require(\"a\");",
+        "Object; isNaN();",
+        "toString()",
+        "hasOwnProperty()",
+        "function evilEval(stuffToEval) { var ultimateAnswer; ultimateAnswer = 42; eval(stuffToEval); }",
+        "typeof a",
+        "typeof (a)",
+        "var b = typeof a",
+        "typeof a === 'undefined'",
+        "if (typeof a === 'undefined') {}",
+        {code: "function foo() { var [a, b=4] = [1, 2]; return {a, b}; }", parserOptions: {ecmaVersion: 6}},
+        {code: "var toString = 1;", parserOptions: {ecmaVersion: 6}},
+        {code: "function myFunc(...foo) {  return foo;}", parserOptions: {ecmaVersion: 6}},
+        {
+            code: "var React, App, a=1; React.render(<App attr={a} />);",
+            parserOptions: {ecmaVersion: 6, ecmaFeatures: {jsx: true}}
+        },
+        {code: "var console; [1,2,3].forEach(obj => {\n  console.log(obj);\n});", parserOptions: {ecmaVersion: 6}},
+        {code: "var Foo; class Bar extends Foo { constructor() { super();  }}", parserOptions: {ecmaVersion: 6}},
+        {
+            code: "import Warning from '../lib/warning'; var warn = new Warning('text');",
+            parserOptions: {sourceType: "module"}
+        },
+        {
+            code: "import * as Warning from '../lib/warning'; var warn = new Warning('text');",
+            parserOptions: {sourceType: "module"}
+        },
+        {code: "var a; [a] = [0];", parserOptions: {ecmaVersion: 6}},
+        {code: "var a; ({a}) = {};", parserOptions: {ecmaVersion: 6}},
+        {code: "var a; ({b: a}) = {};", parserOptions: {ecmaVersion: 6}},
+        {code: "var obj; [obj.a, obj.b] = [0, 1];", parserOptions: {ecmaVersion: 6}},
+        {code: "URLSearchParams;", env: {browser: true}},
+
+        // Notifications of readonly are removed: https://github.com/eslint/eslint/issues/4504
+        {code: "/*global b:false*/ function f() { b = 1; }"},
+        {code: "function f() { b = 1; }", global: {b: false}},
+        {code: "/*global b:false*/ function f() { b++; }"},
+        {code: "/*global b*/ b = 1;"},
+        {code: "/*global b:false*/ var b = 1;"},
+        {code: "Array = 1;"},
+
+        // new.target: https://github.com/eslint/eslint/issues/5420
+        {code: "class A { constructor() { new.target; } }", parserOptions: {ecmaVersion: 6}},
+
+        // Experimental,
+        {
+            code: "var {bacon, ...others} = stuff; foo(others)",
+            parserOptions: {
+                ecmaVersion: 6,
+                ecmaFeatures: {
+                    experimentalObjectRestSpread: true
+                }
+            },
+            globals: {stuff: false, foo: false}
+        }
+    ],
+
+    invalid: [
+        {
+            code: `
+                <For each="element" of={this.props.elements} index="idx">
+                    {wrongElement}
+                </For>
+            `,
+            parserOptions: {
+                ecmaFeatures: {
+                    jsx: true
+                }
+            },
+            errors: [{message: "'wrongElement' is not defined.", type: "Identifier"}]
+        },
+        {
+            code: `
+                <For each="element" of={this.props.elements} index="idx">
+                    <Blah key={wrongElement}></Blah>
+                </For>
+            `,
+            parserOptions: {
+                ecmaFeatures: {
+                    jsx: true
+                }
+            },
+            errors: [{message: "'wrongElement' is not defined.", type: "Identifier"}]
+        },
+        {
+            code: `
+                <For each="element" of={this.props.elements} index="idx">
+                    <WrapperElement>
+                        {wrongElement}
+                    </WrapperElement>
+                </For>
+            `,
+            parserOptions: {
+                ecmaFeatures: {
+                    jsx: true
+                }
+            },
+            errors: [{message: "'wrongElement' is not defined.", type: "Identifier"}]
+        },
+        {
+            code: `
+                <For each="element" of={this.props.elements} index="idx">
+                    <WrapperElement>
+                        <Blah key={wrongElement}></Blah>
+                    </WrapperElement>
+                </For>
+            `,
+            parserOptions: {
+                ecmaFeatures: {
+                    jsx: true
+                }
+            },
+            errors: [{message: "'wrongElement' is not defined.", type: "Identifier"}]
+        }, {
+            code: `
+                <For each="element1" of={this.props.elements} index="idx1">
+                    {idx2} {element2}
+                    <For each="element2" of={this.props.elements} index="idx2">
+                        {element1} {idx1}
+                    </For>
+                </For>
+            `,
+            parserOptions: {
+                ecmaFeatures: {
+                    jsx: true
+                }
+            },
+            errors: [
+                {message: "'idx2' is not defined.", type: "Identifier"},
+                {message: "'element2' is not defined.", type: "Identifier"}
+            ]
+        },
+
+        // standard no-undef rules follow:
+        {code: "a = 1;", errors: [{message: "'a' is not defined.", type: "Identifier"}]},
+        {
+            code: "if (typeof anUndefinedVar === 'string') {}",
+            options: [{typeof: true}],
+            errors: [{message: "'anUndefinedVar' is not defined.", type: "Identifier"}]
+        },
+        {code: "var a = b;", errors: [{message: "'b' is not defined.", type: "Identifier"}]},
+        {code: "function f() { b; }", errors: [{message: "'b' is not defined.", type: "Identifier"}]},
+        {code: "window;", errors: [{message: "'window' is not defined.", type: "Identifier"}]},
+        {code: "require(\"a\");", errors: [{message: "'require' is not defined.", type: "Identifier"}]},
+        {
+            code: "var React; React.render(<img attr={a} />);",
+            errors: [{message: "'a' is not defined."}],
+            parserOptions: {ecmaVersion: 6, ecmaFeatures: {jsx: true}}
+        },
+        {
+            code: "var React, App; React.render(<App attr={a} />);",
+            errors: [{message: "'a' is not defined."}],
+            parserOptions: {ecmaVersion: 6, ecmaFeatures: {jsx: true}}
+        },
+        {code: "[a] = [0];", parserOptions: {ecmaVersion: 6}, errors: [{message: "'a' is not defined."}]},
+        {code: "({a}) = {};", parserOptions: {ecmaVersion: 6}, errors: [{message: "'a' is not defined."}]},
+        {code: "({b: a}) = {};", parserOptions: {ecmaVersion: 6}, errors: [{message: "'a' is not defined."}]},
+        {
+            code: "[obj.a, obj.b] = [0, 1];",
+            parserOptions: {ecmaVersion: 6},
+            errors: [{message: "'obj' is not defined."}, {message: "'obj' is not defined."}]
+        },
+
+        // Experimental
+        {
+            code: "const c = 0; const a = {...b, c};",
+            parserOptions: {
+                ecmaVersion: 6,
+                ecmaFeatures: {
+                    experimentalObjectRestSpread: true
+                }
+            },
+            errors: [{message: "'b' is not defined."}]
+        }
+    ]
+});

--- a/tests/lib/rules/jsx-jcs-no-undef.js
+++ b/tests/lib/rules/jsx-jcs-no-undef.js
@@ -19,42 +19,42 @@ var ruleTester = new RuleTester();
 ruleTester.run("jsx-jcs-no-undef", rule, {
     valid: [
         {
-            code: `
-                <For each="element" of={this.props.elements} index="idx">
-                    {element.textValue}
-                    {idx}
-                    <div>
-                        {element.textValue}
-                        {idx}
-                    </div>
-                </For>
-            `,
+            code:
+                '<For each="element" of={this.props.elements} index="idx">' +
+                    '{element.textValue}' +
+                    '{idx}' +
+                    '<div>' +
+                        '{element.textValue}' +
+                        '{idx}' +
+                    '</div>' +
+                '</For>'
+            ,
             parserOptions: {
                 ecmaFeatures: {
                     jsx: true
                 }
             }
         }, {
-            code: `
-                <For each="element" of={this.props.elements} index="idx">
-                    <AnotherElement foo={element} bar={idx}>
-                        <YetAnotherElement foo={element} bar={idx} />
-                    </AnotherElement>
-                </For>
-            `,
+            code:
+                '<For each="element" of={this.props.elements} index="idx">' +
+                    '<AnotherElement foo={element} bar={idx}>' +
+                        '<YetAnotherElement foo={element} bar={idx} />' +
+                    '</AnotherElement>' +
+                '</For>'
+            ,
             parserOptions: {
                 ecmaFeatures: {
                     jsx: true
                 }
             }
         }, {
-            code: `
-                <For each="element1" of={this.props.elements} index="idx1">
-                    <For each="element2" of={this.props.elements} index="idx2">
-                        {element1} {element2} {idx1} {idx2}
-                    </For>
-                </For>
-            `,
+            code:
+                '<For each="element1" of={this.props.elements} index="idx1">' +
+                    '<For each="element2" of={this.props.elements} index="idx2">' +
+                        '{element1} {element2} {idx1} {idx2}' +
+                    '</For>' +
+                '</For>'
+            ,
             parserOptions: {
                 ecmaFeatures: {
                     jsx: true
@@ -134,11 +134,11 @@ ruleTester.run("jsx-jcs-no-undef", rule, {
 
     invalid: [
         {
-            code: `
-                <For each="element" of={this.props.elements} index="idx">
-                    {wrongElement}
-                </For>
-            `,
+            code:
+                '<For each="element" of={this.props.elements} index="idx">' +
+                    '{wrongElement}' +
+                '</For>'
+            ,
             parserOptions: {
                 ecmaFeatures: {
                     jsx: true
@@ -147,11 +147,11 @@ ruleTester.run("jsx-jcs-no-undef", rule, {
             errors: [{message: "'wrongElement' is not defined.", type: "Identifier"}]
         },
         {
-            code: `
-                <For each="element" of={this.props.elements} index="idx">
-                    <Blah key={wrongElement}></Blah>
-                </For>
-            `,
+            code:
+                '<For each="element" of={this.props.elements} index="idx">' +
+                    '<Blah key={wrongElement}></Blah>' +
+                '</For>'
+            ,
             parserOptions: {
                 ecmaFeatures: {
                     jsx: true
@@ -160,13 +160,13 @@ ruleTester.run("jsx-jcs-no-undef", rule, {
             errors: [{message: "'wrongElement' is not defined.", type: "Identifier"}]
         },
         {
-            code: `
-                <For each="element" of={this.props.elements} index="idx">
-                    <WrapperElement>
-                        {wrongElement}
-                    </WrapperElement>
-                </For>
-            `,
+            code:
+                '<For each="element" of={this.props.elements} index="idx">' +
+                    '<WrapperElement>' +
+                        '{wrongElement}' +
+                    '</WrapperElement>' +
+                '</For>'
+            ,
             parserOptions: {
                 ecmaFeatures: {
                     jsx: true
@@ -175,13 +175,13 @@ ruleTester.run("jsx-jcs-no-undef", rule, {
             errors: [{message: "'wrongElement' is not defined.", type: "Identifier"}]
         },
         {
-            code: `
-                <For each="element" of={this.props.elements} index="idx">
-                    <WrapperElement>
-                        <Blah key={wrongElement}></Blah>
-                    </WrapperElement>
-                </For>
-            `,
+            code:
+                '<For each="element" of={this.props.elements} index="idx">' +
+                    '<WrapperElement>' +
+                        '<Blah key={wrongElement}></Blah>' +
+                    '</WrapperElement>' +
+                '</For>'
+            ,
             parserOptions: {
                 ecmaFeatures: {
                     jsx: true
@@ -189,14 +189,14 @@ ruleTester.run("jsx-jcs-no-undef", rule, {
             },
             errors: [{message: "'wrongElement' is not defined.", type: "Identifier"}]
         }, {
-            code: `
-                <For each="element1" of={this.props.elements} index="idx1">
-                    {idx2} {element2}
-                    <For each="element2" of={this.props.elements} index="idx2">
-                        {element1} {idx1}
-                    </For>
-                </For>
-            `,
+            code:
+                '<For each="element1" of={this.props.elements} index="idx1">' +
+                    '{idx2} {element2}' +
+                    '<For each="element2" of={this.props.elements} index="idx2">' +
+                        '{element1} {idx1}' +
+                    '</For>' +
+                '</For>'
+            ,
             parserOptions: {
                 ecmaFeatures: {
                     jsx: true

--- a/tests/lib/rules/jsx-use-if-tag.js
+++ b/tests/lib/rules/jsx-use-if-tag.js
@@ -39,7 +39,7 @@ ruleTester.run("jsx-use-if-tags", rule, {
                 }
             },
             errors: [{
-                message: "Ternary opertor used. Use 'If' tag instead.",
+                message: "Ternary operator used. Use 'If' tag instead.",
                 type: "ConditionalExpression"
             }]
         }, {
@@ -50,7 +50,7 @@ ruleTester.run("jsx-use-if-tags", rule, {
                 }
             },
             errors: [{
-                message: "Ternary opertor used. Use 'If' tag instead.",
+                message: "Ternary operator used. Use 'If' tag instead.",
                 type: "ConditionalExpression"
             }]
         }, {
@@ -61,7 +61,7 @@ ruleTester.run("jsx-use-if-tags", rule, {
                 }
             },
             errors: [{
-                message: "Ternary opertor used. Use 'If' tag instead.",
+                message: "Ternary operator used. Use 'If' tag instead.",
                 type: "ConditionalExpression"
             }]
         }, {
@@ -72,7 +72,7 @@ ruleTester.run("jsx-use-if-tags", rule, {
                 }
             },
             errors: [{
-                message: "Ternary opertor used. Use 'If' tag instead.",
+                message: "Ternary operator used. Use 'If' tag instead.",
                 type: "ConditionalExpression"
             }]
         }


### PR DESCRIPTION
Hi @vkbansal, really appreciate this plugin, thanks for writing it!

So I've started using the plugin and I've run foul of the problem where ESLint's `no-undef` rule fails in `<For>` loops if you try to reference the `each` or `index` value ( #17 ).

I'm not sure what worked for this before, but I can't see any way to make it work except disabling `no-undef`. So what I've done is copy the existing `no-undef` source and added a bit of code that checks `no-undef` failures to make sure they're not specified by a `<For>` statement by recursing back up the tree and checking against any `<For>` `each` or `index` attributes. Unfortunately this means you've got to turn the original `no-undef` off but it works exactly the same and passes the same tests.

While I was looking at the ESLint documentation I also noticed you could create configurations, so I've added one of those rather than forcing people to opt into all the rules individually, and I also created an environment for all the statements that need to be added to `globals` normally. The recommended configuration enables this new `jsx-jcs-no-undef` rule as a warning and disables the built-in eslint one.

I've included tests for the new rule and it's also working pretty well on our new React implementation of https://github.com/TerriaJS/TerriaJS. Let me know what you think :).
