### PR TITLE
add plugin to the recommended config

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ module.exports = {
             env: {
               "jsx-control-statements/jsx-control-statements": true
             },
+            plugins: ["jsx-control-statements"],
             rules: {
                 "jsx-control-statements/jsx-choose-not-empty": 1,
                 "jsx-control-statements/jsx-for-require-each": 1,


### PR DESCRIPTION
Needs to reference itself so the environment is available when using the recommended config.
Prevents error: Environment key "jsx-control-statements/jsx-control-statements" is unknown